### PR TITLE
python-i3ipc init at 1.3.0

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -582,13 +582,15 @@ in {
       {
         environment = {
           etc = mapAttrs' (name: { packages, ... }: {
-            name = "per-user-pkgs/${name}";
-            value.source = pkgs.symlinkJoin {
-              name = "per-user-pkgs.${name}";
+            name = "profiles/per-user/${name}";
+            value.source = pkgs.buildEnv {
+              name = "user-environment";
               paths = packages;
+              inherit (config.environment) pathsToLink extraOutputsToInstall;
+              inherit (config.system.path) ignoreCollisions postBuild;
             };
           }) (filterAttrs (_: { packages, ... }: packages != []) cfg.users);
-          profiles = ["/etc/per-user-pkgs/$LOGNAME"];
+          profiles = ["/etc/profiles/per-user/$USER"];
         };
       }
     ];

--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,0 +1,35 @@
+{ fetchurl, ncurses, stdenv,
+  updateAutotoolsGnuConfigScriptsHook }:
+
+stdenv.mkDerivation rec {
+  name = "freesweep-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/rwestlund/freesweep/archive/v${version}.tar.gz";
+    sha256 = "0l2kf14558lsq9qd2hs0kcyn9bbl1jdbzwrvcs6mnyjl7zpizcpj";
+  };
+
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+  buildInputs = [ ncurses ];
+
+  preConfigure = ''
+    configureFlags="$configureFlags --with-prefsdir=$out/share"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 0555 freesweep $out/bin/freesweep
+    install -D -m 0444 sweeprc $out/share/sweeprc
+    install -D -m 0444 freesweep.6 $out/share/man/man6/freesweep.6
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A console minesweeper-style game written in C for Unix-like systems";
+    homepage = https://github.com/rwestlund/freesweep;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kierdavis ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/misc/emulators/openmsx/custom-nixos.mk
+++ b/pkgs/misc/emulators/openmsx/custom-nixos.mk
@@ -1,0 +1,9 @@
+# This file substitutes $sourceRoot/build/custom.mk
+
+VERSION_EXEC:=false
+SYMLINK_FOR_BINARY:=false
+INSTALL_CONTRIB:=true
+INSTALL_BASE:=${out}
+INSTALL_DOC_DIR:=${INSTALL_BASE}/share/doc/openmsx
+INSTALL_SHARE_DIR:=${INSTALL_BASE}/share/openmsx
+INSTALL_BINARY_DIR:=${INSTALL_BASE}/bin

--- a/pkgs/misc/emulators/openmsx/default.nix
+++ b/pkgs/misc/emulators/openmsx/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, python
+, alsaLib, glew, mesa_noglu, libpng
+, libogg, libtheora, libvorbis
+, SDL, SDL_image, SDL_ttf
+, freetype, tcl, zlib
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "openmsx-${version}";
+  version = "git-2017-11-02";
+
+  src = fetchFromGitHub {
+    owner = "openMSX";
+    repo = "openMSX";
+    rev = "eeb74206ae347a3b17e9b99f91f2b4682c5db22c";
+    sha256 = "170amj7k6wjhwx6psbplqljvckvhxxbv3aw72jrdxl1fb8zlnq3s";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig python ];
+
+  buildInputs = [ alsaLib glew mesa_noglu libpng
+    libogg libtheora libvorbis freetype
+    SDL SDL_image SDL_ttf tcl zlib ];
+
+  postPatch = ''
+    cp ${./custom-nixos.mk} build/custom.mk
+  '';
+
+  dontAddPrefix = true;
+
+  # Many thanks @mthuurne from OpenMSX project
+  # for providing support to Nixpkgs :)
+  TCL_CONFIG="${tcl}/lib/";
+
+  meta = with stdenv.lib; {
+    description = "A MSX emulator";
+    longDescription = ''
+      OpenMSX is an emulator for the MSX home computer system. Its goal is
+      to emulate all aspects of the MSX with 100% accuracy.
+    '';
+    homepage = https://openmsx.org;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, cmake
 
 # dependencies
 , glib, libXinerama
@@ -72,6 +72,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "15j8h251v9jpdg6h6wn1vb45pkk806pf9s5n3rdrps9r185w8hn8";
   };
+
+  patches = [
+    # Patch to fix compilation on gcc-7 from conky PR
+    # https://github.com/brndnmtthws/conky/pull/402
+    (fetchpatch {
+      name = "gcc7.patch";
+      url = "https://github.com/brndnmtthws/conky/commit/6140122b82d50acc333e5d2a813cc1933ecc6d21.patch";
+      sha256 = "1fblfj1w2kc0gshc2pq9lc1pxxsgmgh8byb1xs2v6amx15kj11k7";
+    })
+  ];
 
   postPatch = ''
     sed -i -e '/include.*CheckIncludeFile)/i include(CheckIncludeFiles)' \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19792,6 +19792,10 @@ with pkgs;
 
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 
+  openmsx = callPackage ../misc/emulators/openmsx {
+    python = python27;
+  };
+
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome2) gtksourceview;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17875,6 +17875,8 @@ with pkgs;
     boost = boost160;
   };
 
+  freesweep = callPackage ../games/freesweep { };
+
   frotz = callPackage ../games/frotz { };
 
   fsg = callPackage ../games/fsg {


### PR DESCRIPTION
###### Motivation for this change

The package [i3ipc-python](https://github.com/ziberna/i3-py) is a better-maintained alternative to [i3-py](https://github.com/ziberna/i3-py) which is currently in nixpkgs.

Contributors: 26 vs 3. 
Last commit: 19 days ago vs 6 years ago

###### Things done

- [ ] Tested using sandboxing
  - Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested the library
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

EDIT: Things done