### PR TITLE
python-i3ipc: init at 1.3.0

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -697,6 +697,7 @@
   womfoo = "Kranium Gikos Mendoza <kranium@gikos.net>";
   wscott = "Wayne Scott <wsc9tt@gmail.com>";
   wyvie = "Elijah Rum <elijahrum@gmail.com>";
+  xaverdh = "Dominik Xaver Hörl <hoe.dom@gmx.de>";
   xnwdd = "Guillermo NWDD <nwdd+nixos@no.team>";
   xvapx = "Marti Serra <marti.serra.coscollano@gmail.com>";
   xwvvvvwx = "David Terry <davidterry@posteo.de>";

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -582,13 +582,15 @@ in {
       {
         environment = {
           etc = mapAttrs' (name: { packages, ... }: {
-            name = "per-user-pkgs/${name}";
-            value.source = pkgs.symlinkJoin {
-              name = "per-user-pkgs.${name}";
+            name = "profiles/per-user/${name}";
+            value.source = pkgs.buildEnv {
+              name = "user-environment";
               paths = packages;
+              inherit (config.environment) pathsToLink extraOutputsToInstall;
+              inherit (config.system.path) ignoreCollisions postBuild;
             };
           }) (filterAttrs (_: { packages, ... }: packages != []) cfg.users);
-          profiles = ["/etc/per-user-pkgs/$LOGNAME"];
+          profiles = ["/etc/profiles/per-user/$USER"];
         };
       }
     ];

--- a/pkgs/applications/misc/oneko/default.nix
+++ b/pkgs/applications/misc/oneko/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, xorg, x11 }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.sakura.5";
+  vname = "1.2.5";
+  name = "oneko-${vname}";
+  src = fetchurl {
+    url = "http://www.daidouji.com/oneko/distfiles/oneko-${version}.tar.gz";
+    sha256 = "2c2e05f1241e9b76f54475b5577cd4fb6670de058218d04a741a04ebd4a2b22f";
+  };
+  buildInputs = [ xorg.imake xorg.gccmakedep x11 ];
+  
+  configurePhase = "xmkmf";
+
+  installPhase = ''
+    make install BINDIR=$out/bin
+    make install.man MANPATH=$out/share/man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Creates a cute cat chasing around your mouse cursor";
+    longDescription = ''
+    Oneko changes your mouse cursor into a mouse
+    and creates a little cute cat, which starts
+    chasing around your mouse cursor.
+    When the cat is done catching the mouse, it starts sleeping.
+    '';
+    homepage = "http://www.daidouji.com/oneko/";
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.xaverdh ];
+    meta.platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/games/freesweep/default.nix
+++ b/pkgs/games/freesweep/default.nix
@@ -1,0 +1,35 @@
+{ fetchurl, ncurses, stdenv,
+  updateAutotoolsGnuConfigScriptsHook }:
+
+stdenv.mkDerivation rec {
+  name = "freesweep-${version}";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/rwestlund/freesweep/archive/v${version}.tar.gz";
+    sha256 = "0l2kf14558lsq9qd2hs0kcyn9bbl1jdbzwrvcs6mnyjl7zpizcpj";
+  };
+
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+  buildInputs = [ ncurses ];
+
+  preConfigure = ''
+    configureFlags="$configureFlags --with-prefsdir=$out/share"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 0555 freesweep $out/bin/freesweep
+    install -D -m 0444 sweeprc $out/share/sweeprc
+    install -D -m 0444 freesweep.6 $out/share/man/man6/freesweep.6
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A console minesweeper-style game written in C for Unix-like systems";
+    homepage = https://github.com/rwestlund/freesweep;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kierdavis ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/misc/emulators/openmsx/custom-nixos.mk
+++ b/pkgs/misc/emulators/openmsx/custom-nixos.mk
@@ -1,0 +1,9 @@
+# This file substitutes $sourceRoot/build/custom.mk
+
+VERSION_EXEC:=false
+SYMLINK_FOR_BINARY:=false
+INSTALL_CONTRIB:=true
+INSTALL_BASE:=${out}
+INSTALL_DOC_DIR:=${INSTALL_BASE}/share/doc/openmsx
+INSTALL_SHARE_DIR:=${INSTALL_BASE}/share/openmsx
+INSTALL_BINARY_DIR:=${INSTALL_BASE}/bin

--- a/pkgs/misc/emulators/openmsx/default.nix
+++ b/pkgs/misc/emulators/openmsx/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, pkgconfig
+, python
+, alsaLib, glew, mesa_noglu, libpng
+, libogg, libtheora, libvorbis
+, SDL, SDL_image, SDL_ttf
+, freetype, tcl, zlib
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "openmsx-${version}";
+  version = "git-2017-11-02";
+
+  src = fetchFromGitHub {
+    owner = "openMSX";
+    repo = "openMSX";
+    rev = "eeb74206ae347a3b17e9b99f91f2b4682c5db22c";
+    sha256 = "170amj7k6wjhwx6psbplqljvckvhxxbv3aw72jrdxl1fb8zlnq3s";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig python ];
+
+  buildInputs = [ alsaLib glew mesa_noglu libpng
+    libogg libtheora libvorbis freetype
+    SDL SDL_image SDL_ttf tcl zlib ];
+
+  postPatch = ''
+    cp ${./custom-nixos.mk} build/custom.mk
+  '';
+
+  dontAddPrefix = true;
+
+  # Many thanks @mthuurne from OpenMSX project
+  # for providing support to Nixpkgs :)
+  TCL_CONFIG="${tcl}/lib/";
+
+  meta = with stdenv.lib; {
+    description = "A MSX emulator";
+    longDescription = ''
+      OpenMSX is an emulator for the MSX home computer system. Its goal is
+      to emulate all aspects of the MSX with 100% accuracy.
+    '';
+    homepage = https://openmsx.org;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, cmake
 
 # dependencies
 , glib, libXinerama
@@ -72,6 +72,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "15j8h251v9jpdg6h6wn1vb45pkk806pf9s5n3rdrps9r185w8hn8";
   };
+
+  patches = [
+    # Patch to fix compilation on gcc-7 from conky PR
+    # https://github.com/brndnmtthws/conky/pull/402
+    (fetchpatch {
+      name = "gcc7.patch";
+      url = "https://github.com/brndnmtthws/conky/commit/6140122b82d50acc333e5d2a813cc1933ecc6d21.patch";
+      sha256 = "1fblfj1w2kc0gshc2pq9lc1pxxsgmgh8byb1xs2v6amx15kj11k7";
+    })
+  ];
 
   postPatch = ''
     sed -i -e '/include.*CheckIncludeFile)/i include(CheckIncludeFiles)' \

--- a/pkgs/servers/openafs-client/default.nix
+++ b/pkgs/servers/openafs-client/default.nix
@@ -22,6 +22,18 @@ stdenv.mkDerivation rec {
       url = "http://git.openafs.org/?p=openafs.git;a=patch;h=c193e5cba18273a062d4162118c7055b54f7eb5e";
       sha256 = "1yc4gygcazwsslf6mzk1ai92as5jbsjv7212jcbb2dw83jydhc09";
     })
+    # linux 4.14
+    (fetchpatch {
+      name = "test-for-__vfs_write-rather-than-__vfs_read.patch";
+      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=929e77a886fc9853ee292ba1aa52a920c454e94b";
+      sha256 = "0g4jxqzvyrjy2q7mhxc5ikhypj3ljw1wri4lipzm66crsvycp9x5";
+    })
+    # linux 4.14
+    (fetchpatch {
+      name = "use-kernel_read-kernel_write-when-__vfs-variants-are-unavailable.patch";
+      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=5ee516b3789d3545f3d78fb3aba2480308359945";
+      sha256 = "1vx55qb120y857mn1l00i58fj9cckschp86ch3g6hqrdc5q5bxv2";
+    })
   ];
 
   preConfigure = ''

--- a/pkgs/tools/system/lr/default.nix
+++ b/pkgs/tools/system/lr/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lr-${version}";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "lr";
     rev = "v${version}";
-    sha256 = "171h353238s9wmhirvs2yc1151vds83a71p7wgn96wa3jpl248by";
+    sha256 = "1536d723dm50gxgpf8i9yij8mr0csh662ljhs5bmz0945jwfbx4n";
   };
 
   makeFlags = "PREFIX=$(out)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19792,6 +19792,10 @@ with pkgs;
 
   snes9x-gtk = callPackage ../misc/emulators/snes9x-gtk { };
 
+  openmsx = callPackage ../misc/emulators/openmsx {
+    python = python27;
+  };
+
   higan = callPackage ../misc/emulators/higan {
     inherit (gnome2) gtksourceview;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17875,6 +17875,8 @@ with pkgs;
     boost = boost160;
   };
 
+  freesweep = callPackage ../games/freesweep { };
+
   frotz = callPackage ../games/frotz { };
 
   fsg = callPackage ../games/fsg {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10056,6 +10056,8 @@ with pkgs;
 
   olm = callPackage ../development/libraries/olm { };
 
+  oneko = callPackage ../applications/misc/oneko { };   
+
   oniguruma = callPackage ../development/libraries/oniguruma { };
 
   openal = self.openalSoft;


### PR DESCRIPTION
###### Motivatio###### Motivation for this change

The package [i3ipc-python](https://github.com/ziberna/i3-py) is a better-maintained alternative to [i3-py](https://github.com/ziberna/i3-py) which is currently in nixpkgs.

Contributors: 26 vs 3. 
Last commit: 19 days ago vs 6 years ago

###### Things done

- [ ] Tested using sandboxing
  - Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [x] Tested the library
- [x] Fits [CONTRIBUTING.md]